### PR TITLE
initialize messageNumber in init

### DIFF
--- a/services/FetchHeadersService.py
+++ b/services/FetchHeadersService.py
@@ -22,6 +22,7 @@ class FetchHeadersService(QThread):
         self.emailList = []
         self.idList = []
         self.idDict = {}
+        self.messageNumber = 0
 
     def addToList(self, messageID, sender_, email_, subject_):
         self.idList.append(messageID)


### PR DESCRIPTION
Main window could crash when selecting different folders quickly.
It may help to avoid that.